### PR TITLE
upgrade to jsx v4 & react 18

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -18,8 +18,9 @@
     }
   ],
   "suffix": ".bs.js",
-  "reason": {
-    "react-jsx": 3
+  "jsx": {
+    "version": 4,
+    "mode": "automatic"
   },
   "bs-dependencies": [
     "@rescript/react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@rescript/core": "^0.1.0",
-        "@rescript/react": "^0.10.3",
+        "@rescript/react": "^0.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rescript-webapi": "^0.7.0"
@@ -893,12 +893,12 @@
       "integrity": "sha512-+nJiH67zp/CD6qwFv9VxlAknlYf/lIb6Q72Nqc0tvoMUizX+sRKQxQVUQSIqG+MSoxCUlSVye1wmZFwbNmJKpw=="
     },
     "node_modules/@rescript/react": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.10.3.tgz",
-      "integrity": "sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
+      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
       "peerDependencies": {
-        "react": ">=16.8.1",
-        "react-dom": ">=16.8.1"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -3888,9 +3888,9 @@
       "integrity": "sha512-+nJiH67zp/CD6qwFv9VxlAknlYf/lIb6Q72Nqc0tvoMUizX+sRKQxQVUQSIqG+MSoxCUlSVye1wmZFwbNmJKpw=="
     },
     "@rescript/react": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.10.3.tgz",
-      "integrity": "sha512-Lf9rzrR3bQPKJjOK3PBRa/B3xrJ7CqQ1HYr9VHPVxJidarIJJFZBhj0Dg1uZURX+Wg/xiP0PHFxXmdj2bK8Vxw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
+      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
       "requires": {}
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@rescript/core": "^0.1.0",
-    "@rescript/react": "^0.10.3",
+    "@rescript/react": "^0.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rescript-webapi": "^0.7.0"

--- a/src/Main.res
+++ b/src/Main.res
@@ -1,6 +1,7 @@
-ReactDOM.render(
+let root = ReactDOM.Client.createRoot(ReactDOM.querySelector("#root")->Option.getExn)
+ReactDOM.Client.Root.render(
+  root,
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  ReactDOM.querySelector("#root")->Option.getExn,
 )

--- a/src/Main.res
+++ b/src/Main.res
@@ -1,6 +1,7 @@
-let root = ReactDOM.Client.createRoot(ReactDOM.querySelector("#root")->Option.getExn)
-ReactDOM.Client.Root.render(
-  root,
+ReactDOM.querySelector("#root")
+->Option.getExn
+->ReactDOM.Client.createRoot
+->ReactDOM.Client.Root.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,


### PR DESCRIPTION
* Updates to rescript-react 0.11.0:
  * Enables rescript-react JSX v4.
  * Switches to [new jsx transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).

* Changes to react 18 rendering API, functioning as the version toggle for new behaviors:
  * Concurrent rendering.
  * [Stricter strict mode](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-strict-mode), apparently. As far as I can tell this only enables the intentional-double-mount-in-dev-mode feature, no adverse effects noticed in this repo.