### PR TITLE
migrate rescript to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "autoprefixer": "^10.4.16",
         "jsdom": "^22.1.0",
         "postcss": "^8.4.32",
-        "rescript": "^10.1.4",
+        "rescript": "^11.0.1",
         "rescript-vitest": "^1.3.0",
         "tailwindcss": "^3.4.0",
         "vite": "^5.0.10",
@@ -3828,15 +3828,17 @@
       "dev": true
     },
     "node_modules/rescript": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.4.tgz",
-      "integrity": "sha512-FFKlS9AG/XrLepWsyw7B+A9DtQBPWEPDPDKghV831Y2KGbie+eeFBOS0xtRHp0xbt7S0N2Dm6hhX+kTZQ/3Ybg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.1.tgz",
+      "integrity": "sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg==",
       "hasInstallScript": true,
       "bin": {
         "bsc": "bsc",
-        "bsrefmt": "bsrefmt",
         "bstracing": "lib/bstracing",
         "rescript": "rescript"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/rescript-vitest": {
@@ -7348,9 +7350,9 @@
       "dev": true
     },
     "rescript": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.4.tgz",
-      "integrity": "sha512-FFKlS9AG/XrLepWsyw7B+A9DtQBPWEPDPDKghV831Y2KGbie+eeFBOS0xtRHp0xbt7S0N2Dm6hhX+kTZQ/3Ybg=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.1.tgz",
+      "integrity": "sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg=="
     },
     "rescript-vitest": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "autoprefixer": "^10.4.16",
     "jsdom": "^22.1.0",
     "postcss": "^8.4.32",
-    "rescript": "^10.1.4",
+    "rescript": "^11.0.1",
     "rescript-vitest": "^1.3.0",
     "tailwindcss": "^3.4.0",
     "vite": "^5.0.10",

--- a/rescript.json
+++ b/rescript.json
@@ -22,6 +22,7 @@
     "version": 4,
     "mode": "automatic"
   },
+  "uncurried": false,
   "bs-dependencies": ["@rescript/react", "@rescript/core", "rescript-webapi"],
   "bs-dev-dependencies": ["rescript-vitest"],
   "bsc-flags": ["-open RescriptCore"]


### PR DESCRIPTION
#21 

Tested it locally and it works, had to opt out of uncurried mode tho because of an error generated by `rescript-vitest` which is up to date, see this issue https://github.com/cometkim/rescript-vitest/issues/14