### PR TITLE
update @rescript/react to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@rescript/core": "^0.6.0",
-        "@rescript/react": "^0.11.0",
+        "@rescript/react": "^0.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rescript-webapi": "^0.9.0"
@@ -997,9 +997,9 @@
       }
     },
     "node_modules/@rescript/react": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
-      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0.tgz",
+      "integrity": "sha512-EBLsf5rD7sJOjgfLLGwuLw/hONszc3UtYnIVgv7OdTyUNR41/m4deVm62PI0agvr3kWakXz4KchKRSd+19/bRA==",
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
@@ -5345,9 +5345,9 @@
       "requires": {}
     },
     "@rescript/react": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
-      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0.tgz",
+      "integrity": "sha512-EBLsf5rD7sJOjgfLLGwuLw/hONszc3UtYnIVgv7OdTyUNR41/m4deVm62PI0agvr3kWakXz4KchKRSd+19/bRA==",
       "requires": {}
     },
     "@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@rescript/core": "^0.6.0",
-    "@rescript/react": "^0.11.0",
+    "@rescript/react": "^0.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rescript-webapi": "^0.9.0"


### PR DESCRIPTION
as mentionned in #22 & #23 @rescript/react 0.12.0 is now required because of the React.fragment's children type fix. https://github.com/rescript-lang/rescript-compiler/pull/6238